### PR TITLE
Addressableリソースの解放タイミングを修正

### DIFF
--- a/Assets/Scripts/System/GameMaster.cs
+++ b/Assets/Scripts/System/GameMaster.cs
@@ -59,14 +59,6 @@ namespace Game.System
             initialized = true;
         }
 
-        void OnDestroy()
-        {
-            foreach (var address in charaAddressDic.Values)
-            {
-                ResourceStore.Instance.Unload(address);
-            }
-        }
-
         public Vector3 GetCameraTopLeft()
         {
             var tl = camera.ScreenToWorldPoint(Vector3.zero);

--- a/Assets/Scripts/System/ResourceStore.cs
+++ b/Assets/Scripts/System/ResourceStore.cs
@@ -22,6 +22,15 @@ namespace Game.System
             }
         }
 
+        void OnDestroy()
+        {
+            foreach (var obj in objects.Values)
+            {
+                Addressables.Release(obj);
+            }
+            objects.Clear();
+        }
+
         public async Task Load(string address)
         {
             if (objects.ContainsKey(address))


### PR DESCRIPTION
他のOnDestroy()などに置くとリソースストア自身がnull参照になる可能性が十分にあったため。